### PR TITLE
Fix #85 - Invalid icon & validation improvements

### DIFF
--- a/src/Widgets/Views/Editor.vala
+++ b/src/Widgets/Views/Editor.vala
@@ -81,7 +81,7 @@ namespace Webpin.Widgets.Views {
             }
 
             //welcome message
-            message = new Gtk.Label (_ ("Create a new web app"));
+            message = new Gtk.Label (""); // set in {@link reset_fields} or {@link edit_desktop_file}
             message.get_style_context ().add_class ("h2");
             //app information
             icon_button = new Gtk.Button ();
@@ -486,6 +486,7 @@ namespace Webpin.Widgets.Views {
             icon_button.set_image (new Gtk.Image.from_icon_name (default_app_icon, Gtk.IconSize.DIALOG));
             minimal_view_mode.active = false;
             mode = assistant_mode.new_app;
+            message.set_text (_ ("Create a new web app"));
         }
 
         private void on_accept () {
@@ -533,6 +534,7 @@ namespace Webpin.Widgets.Views {
                 reset_fields ();
             } else {
                 mode = assistant_mode.edit_app;
+                message.set_text (_ ("Edit web app"));
                 app_name_entry.text = desktop_file.name;
                 app_name_entry.set_sensitive (false);
                 app_url_entry.text = desktop_file.url.replace ("%%", "%");

--- a/src/Widgets/WebItem.vala
+++ b/src/Widgets/WebItem.vala
@@ -94,7 +94,7 @@ namespace Webpin.Widgets {
         }
 
         private void set_icon (string icon) {
-            if (File.new_for_path (icon).query_exists ()) {
+            if (icon.has_prefix("/") && File.new_for_path (icon).query_exists ()) {
                 Gdk.Pixbuf pix = null;
                 try {
                     pix = new Gdk.Pixbuf.from_file (icon);

--- a/src/Windows/WebApp.vala
+++ b/src/Windows/WebApp.vala
@@ -112,7 +112,7 @@ namespace Webpin.Windows {
             });
 
             browser.found_website_color.connect ((color) => {
-                stdout.printf ("%s\n", color.to_string ());
+                stdout.printf ("found website color: %s\n", color.to_string ());
                 int gray_val = (int)(desktop_file.color.red * 255);
                 if (desktop_file.color == null || ((gray_val == 222 || gray_val == 255) && desktop_file.color.red == desktop_file.color.green && desktop_file.color.red == desktop_file.color.blue)) {
                     set_color (color);


### PR DESCRIPTION
Well - first, the 'edit' view showed "create new web app".

#### Then the bug:
When no icon is found / selected, the icon_name is empty, but later the [on_accept code checks `File.new_for_path ("").query_exist ()`](https://github.com/artemanufrij/webpin/blob/0d1a509/src/Widgets/Views/Editor.vala#L494) - which will just resolve to the working directory, and as that exists, it tries to load the working directory as icon:

> WARNING **: Editor.vala:503: Failed to open file “”: No such file or directory

I fixed that by [wrapping with `icon.has_prefix("/")`](https://github.com/TeNNoX/webpin/commit/36ba877406ef83ce3f4e26fd441d3a2a666307ce)

#### And I also worked on the UX for invalid fields (https://github.com/TeNNoX/webpin/commit/0d82f02bd3acd7da8c94ded02da6da2bfa24cda4)
In some cases, the UI didn't show if fields are invalid - so the user doesn't know why the **Save** button is greyed out.
That's the UX problem of e.g. #85 (you don't see the icon is considered 'invalid')

I refactored so that Form field error status is updated in `.validate` (now called `updateFormStatus`), and the change listeners only set the validity boolean.



#### Other things I fixed along the way
1. update the icon back to default if the name field is cleared.

2. I also added validation feedback for the image button (although it feels weird to set class 'destructive-action', I found it to be the easiest :P)

3. I also changed path detection from `.contains ("/")` to `.has_prefix ("/")` as I think we always have absolute paths. And I'm not sure if theme icon names could contain a '/'.
