### PR TITLE
Add flatpak manifest file

### DIFF
--- a/com.github.artemanufrij.webpin.yml
+++ b/com.github.artemanufrij.webpin.yml
@@ -1,0 +1,31 @@
+# This is the same ID that you've used in meson.build and other files
+app-id: com.github.artemanufrij.webpin
+
+# Instead of manually specifying a long list of build and runtime dependencies,
+# we can use a convenient pre-made runtime and SDK. For this example, we'll be
+# using the runtime and SDK provided by elementary.
+runtime: io.elementary.Platform
+runtime-version: '6'
+sdk: io.elementary.Sdk
+
+# This should match the exec line in your .desktop file and usually is the same
+# as your app ID
+command: com.github.artemanufrij.webpin
+
+# Here we can specify the kinds of permissions our app needs to run. Since we're
+# not using hardware like webcams, making sound, or reading external files, we
+# only need permission to draw our app on screen using either X11 or Wayland.
+finish-args:
+  - '--share=ipc'
+  - '--socket=fallback-x11'
+  - '--socket=wayland'
+
+# This section is where you list all the source code required to build your app.
+# If we had external dependencies that weren't included in our SDK, we would list
+# them here.
+modules:
+  - name: webpin
+    buildsystem: meson
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
Hi,

Elementary OS 6 requires Flatpaks for the App Center, as noted in #143 .

To assist with this, I have created a Flatpak manifest file as per the directions listed here: https://docs.elementary.io/develop/writing-apps/our-first-app/packaging#flatpak-manifest

I am able to build the Flatpak and install using:
`flatpak-builder build com.github.artemanufrij.webpin.yml --user --install --force-clean
`

Once this pull request is merged, webpin may be resubmitted to the App Center.

Thanks,

Jaidev V.